### PR TITLE
Update +layout.svelte

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -129,7 +129,7 @@
 			</div>
 		</svelte:fragment>
 		<svelte:fragment slot="sidebarLeft">
-			<div class="flex h-full flex-col py-[2vw] md:w-[6.25vw]">
+			<div class="flex h-full flex-col justify-between py-[2vw] md:w-[6.25vw]">
 				<div class="flex flex-col items-center gap-5">
 					{#each Object.entries(icon_mapping.top) as item}
 						{@const item_icon = item[1].icon}
@@ -147,7 +147,7 @@
 					{/each}
 				</div>
 
-				<div class="flex flex-col items-center gap-[1.5vw] mt-[2.5vw]">
+				<div class="flex flex-col items-center md:gap-5 2xl:gap-9">
 					{#each Object.entries(icon_mapping.middle) as item}
 						{@const item_name = item[0]}
 						{@const item_icon = item[1].icon}
@@ -198,7 +198,7 @@
 					{/each}
 				</div>
 
-				<div class="flex flex-col-reverse items-center md:gap-[1.5vw] mt-[3vw]">
+				<div class="flex flex-col-reverse items-center md:gap-[0.75vw]">
 					{#each Object.entries(icon_mapping.bottom) as item}
 						{@const item_name = item[0]}
 						{@const item_icon = item[1].icon}


### PR DESCRIPTION
I think its better to have the old codes.

The new one looks like this :

![Screenshot from 2023-04-16 17-56-09](https://user-images.githubusercontent.com/61817579/232308211-427bc2ee-bb47-4b41-bf43-bc90ccc858c1.png)

What i would suggest as improvement is to : 

```html
<button
	type="button"
	class="{is_active
		? 'relative bg-secondary-100 before:absolute before:-left-0.5 before:z-10 before:h-[0.875vw] before:w-[0.25vw] before:rounded-lg before:bg-primary-500'
		: 'bg-initial'} btn-icon relative rounded-[0.5vw] p-0 md:w-[3.375vw]"
	on:click={() => middle_section_click(item_name)}
>
	<div class="inline-grid">
		{#if !is_active}
			<div
				class="absolute inset-0 flex flex-col items-center justify-center md:gap-[0.75vw]"
				transition:blur|local
			>
				<svelte:component
					this={component}
					height={component_height}
					width={component_width}
					color={item_icon.color}
				/>
				<span class="capitalize md:text-[0.875vw] md:leading-[1.05vw]">{item_name}</span
				>
			</div>
		{:else}
			<div
				class="absolute inset-0 flex items-center justify-center"
				transition:blur|local
			>
				<svelte:component
					this={component}
					height={component_height}
					width={component_width}
					color="black"
				/>
			</div>
		{/if}
	</div>
</button>
```

optimize this